### PR TITLE
fix error when there are no options to instead print message to user.

### DIFF
--- a/lunch.coffee
+++ b/lunch.coffee
@@ -30,8 +30,11 @@ module.exports = (robot) ->
     msg.send 'Very well. You shall have ' + newOpt + '. Maybe.'
 
   robot.respond /lunch (opts|options)$/i, (msg) ->
-    opts = robot.brain.get('lunches')
-    msg.send 'Your available lunches: ' + opts.join(', ')
+    if robot.brain.get('lunches')
+      opts = robot.brain.get('lunches')
+      msg.send 'Your available lunches: ' + opts.join(', ')
+    else
+      msg.send 'You need to add some lunch options or else you will only eat Chipotle.'
 
   robot.respond /lunch (del|delete) (.*)$/i, (msg) ->
     opts = robot.brain.get('lunches')


### PR DESCRIPTION
If there are no options added, attempting to do a `join` on null will result in an ERROR TypeError. Instead of that this fix will resolve this issue by printing to the user that they need to add some options.

Thanks for the lunch script, we will most likely use it at our company as well!

:+1: 
